### PR TITLE
generate map file at build

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "main": "dist/npm/src/index.js",
   "files": [
+    "src",
     "dist/**/*"
   ],
   "exports": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
      "target": "ES2020",
      "outDir": "./dist/npm",
      "declaration": true,
-     "declarationMap": false,
+     "declarationMap": true,
      "noImplicitAny": true,
      "noUnusedLocals": true,
      "removeComments": true,


### PR DESCRIPTION
- Fix to generate map file at build time.
- Fix to include the src file in the publishing package

This makes it possible to check helpers, etc. with a ts file instead of a js file and a d.ts file, where implementation and type information are separated when using IDE.

Increases package size: 
- before: 116K
- after: 224K